### PR TITLE
Revert "CFEAREPO-1: Updating with carbon-data 4.4.0 features"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,6 @@
         <carbon.data.version.4.3.1>4.3.1</carbon.data.version.4.3.1>
         <carbon.data.version.4.3.4>4.3.4</carbon.data.version.4.3.4>
         <carbon.data.version.4.3.5>4.3.5</carbon.data.version.4.3.5>
-        <carbon.data.version.4.4.0>4.4.0</carbon.data.version.4.4.0>
         <carbon.deployment.version.4.4.1>4.4.1</carbon.deployment.version.4.4.1>
         <carbon.deployment.version.4.5.2>4.5.2</carbon.deployment.version.4.5.2>
         <carbon.deployment.version.4.5.3>4.5.3</carbon.deployment.version.4.5.3>
@@ -1739,43 +1738,22 @@
                                     org.wso2.carbon.data:org.wso2.carbon.cassandra-jdbc-1.2.5.server.feature:${carbon.data.version.4.3.4}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.data:org.wso2.carbon.cassandra-jdbc-1.2.5.server.feature:${carbon.data.version.4.4.0}
-                                </featureArtifactDef>
-                                <featureArtifactDef>
                                     org.wso2.carbon.data:org.wso2.carbon.dataservices.feature:${carbon.data.version.4.3.4}
-                                </featureArtifactDef>
-                                <featureArtifactDef>
-                                    org.wso2.carbon.data:org.wso2.carbon.dataservices.feature:${carbon.data.version.4.4.0}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.data:org.wso2.carbon.dataservices.server.feature:${carbon.data.version.4.3.4}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.data:org.wso2.carbon.dataservices.server.feature:${carbon.data.version.4.4.0}
-                                </featureArtifactDef>
-                                <featureArtifactDef>
                                     org.wso2.carbon.data:org.wso2.carbon.dataservices.ui.feature:${carbon.data.version.4.3.4}
-                                </featureArtifactDef>
-                                <featureArtifactDef>
-                                    org.wso2.carbon.data:org.wso2.carbon.dataservices.ui.feature:${carbon.data.version.4.4.0}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.data:org.wso2.carbon.dataservices.task.feature:${carbon.data.version.4.3.4}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.data:org.wso2.carbon.dataservices.task.feature:${carbon.data.version.4.4.0}
-                                </featureArtifactDef>
-                                <featureArtifactDef>
                                     org.wso2.carbon.data:org.wso2.carbon.dataservices.task.server.feature:${carbon.data.version.4.3.4}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.data:org.wso2.carbon.dataservices.task.server.feature:${carbon.data.version.4.4.0}
-                                </featureArtifactDef>
-                                <featureArtifactDef>
                                     org.wso2.carbon.data:org.wso2.carbon.dataservices.task.ui.feature:${carbon.data.version.4.3.4}
-                                </featureArtifactDef>
-                                <featureArtifactDef>
-                                    org.wso2.carbon.data:org.wso2.carbon.dataservices.task.ui.feature:${carbon.data.version.4.4.0}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.data:org.wso2.carbon.datasource.reader.hadoop.server.feature:${carbon.data.version.4.3.1}
@@ -1784,19 +1762,10 @@
                                     org.wso2.carbon.data:org.wso2.carbon.datasource.reader.hadoop.server.feature:${carbon.data.version.4.3.5}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.data:org.wso2.carbon.datasource.reader.hadoop.server.feature:${carbon.data.version.4.4.0}
-                                </featureArtifactDef>
-                                <featureArtifactDef>
                                     org.wso2.carbon.data:org.wso2.carbon.datasource.reader.cassandra.server.feature:${carbon.data.version.4.3.1}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
                                     org.wso2.carbon.data:org.wso2.carbon.datasource.reader.cassandra.server.feature:${carbon.data.version.4.3.5}
-                                </featureArtifactDef>
-                                <featureArtifactDef>
-                                    org.wso2.carbon.data:org.wso2.carbon.datasource.reader.cassandra.server.feature:${carbon.data.version.4.4.0}
-                                </featureArtifactDef>
-                                <featureArtifactDef>
-                                    org.wso2.carbon:org.wso2.carbon.dbconsole.ui.feature:${carbon.data.version.4.4.0}
                                 </featureArtifactDef>
 
                                 <featureArtifactDef>
@@ -4004,9 +3973,6 @@
                                 <featureArtifactDef>
                                     org.wso2.carbon.data:org.wso2.carbon.dataservices-hosting.category.feature:${carbon.data.version.4.3.4}
                                 </featureArtifactDef>
-                                <featureArtifactDef>
-                                    org.wso2.carbon.data:org.wso2.carbon.dataservices-hosting.category.feature:${carbon.data.version.4.4.0}
-                                </featureArtifactDef>
 
                                 <featureArtifactDef>
                                     org.wso2.carbon.deployment:org.wso2.carbon.javaee-6-web-profile.category.feature:${carbon.deployment.version.4.5.3}
@@ -4294,10 +4260,6 @@
                                         <catFeature>
                                             <id>org.wso2.carbon.dataservices-hosting.category</id>
                                             <version>${carbon.data.version.4.3.4}</version>
-                                        </catFeature>
-                                        <catFeature>
-                                            <id>org.wso2.carbon.dataservices-hosting.category</id>
-                                            <version>${carbon.data.version.4.4.0}</version>
                                         </catFeature>
                                     </features>
                                 </category>


### PR DESCRIPTION
Reverts wso2/carbon-feature-repository#65 due to missing org.wso2.carbon:org.wso2.carbon.dbconsole.ui.feature:zip:4.4.0 in nexus
